### PR TITLE
[RED-128] Update to footer to allow multiple logos

### DIFF
--- a/style.css
+++ b/style.css
@@ -398,10 +398,10 @@ form .gform_button svg { width: 10px; height: 17px; stroke:currentColor; margin:
 .footer-map svg { width: 13px; height: 18px; margin-left: 4px; opacity: 0.75; }
 
 /* Accreditations */
-.footer-accreditations { display: flex; flex-direction: column; grid-column: span 1; }
-.footer-logo { margin-right: 20px; max-width: 128px; }
-.footer-logo img { position: absolute; top:0; bottom: 0; right: 0; left: 0; object-fit: cover; }
-.footer-logo .image { position: relative; padding-top: 75%; }
+.footer-accreditations { display: flex; flex-direction: row; }
+.footer-logo { margin-right: 20px; margin-top:20px;  }
+.footer-logo img { position: absolute; top:0; bottom: 0; right: 0; left: 0; object-fit: cover; height:auto;}
+.footer-logo .image { position: relative; padding-top: 75%; width:175px; }
 
 /* Copyright */
 .footer-copyright { grid-column: span 3; display: flex; position: relative; z-index: 1; }
@@ -641,9 +641,9 @@ form .gform_button svg { width: 10px; height: 17px; stroke:currentColor; margin:
   .footer .grid { grid-template-columns: repeat(2, 1fr); grid-gap:20px; }
   .footer-menu { grid-column: 1; }
   .footer-menu-item-link { line-height: 1.285714285714286; }
-  .footer-accreditations { grid-column: 2; grid-row: 1; }
   .footer-useful-links { grid-column: span 2; } 
-  .footer-logo { max-width: 96px; }
+  .footer-logo { max-width: 129px; }
+  .footer .image {height:129px;}
   .footer-address h3, .footer-menu h3 { margin-bottom: 8px; font-size: 16px; }
   .footer-social { grid-column: 2; grid-row: 3; }
   .footer-copyright { grid-column: 1/-1; }

--- a/style.css
+++ b/style.css
@@ -285,7 +285,7 @@ form .gform_button svg { width: 10px; height: 17px; stroke:currentColor; margin:
 .accordion-title::marker, .accordion-title::-webkit-details-marker  { display: none; }
 .accordion-title svg { width: 32px; height: 18px; position: absolute; right: 0; top:0; bottom: 0; margin: auto; transition: all 0.3s cubic-bezier(.77,0,.175,1); stroke:currentColor; }
 .accordion { padding: 0 27px; max-width: 920px; width: 100%; margin: auto; }
-.accordion.is-open svg { transform: rotate(180deg); -moz-border-bottom-colors: }
+.accordion.is-open svg { transform: rotate(180deg); }
 .accordion-title-inner { max-width: 516px; width: 100%; margin: auto; position: relative; }
 .accordion-text { transition: max-height 1s cubic-bezier(.77,0,.175,1); max-height: 0; overflow: hidden; }
 .accordion-text-inner { padding: 15px 0 30px 0;  border-bottom: 1px solid #07325e;  margin: 15px 0 50px 0; border-top: 1px solid #07325e; }

--- a/views/partials/footer.twig
+++ b/views/partials/footer.twig
@@ -64,37 +64,38 @@
 			</a>
 			{% endfor %}
 		</nav>
-		
+	</div>	
+	<div class="container grid columns-1">
 		{% if options.footer.logos %}
-		<nav class="footer-accreditations">
-			{% for item in options.footer.logos %}
-				{% if item.link %}
-					<a href="{{ item.link.url }}" class="footer-logo" target="_blank">
-				{% else %}
-					<div class="footer-logo">
-				{% endif %}
+				<div class="footer-accreditations">
+					{% for item in options.footer.logos %}
+						{% if item.link %}
+							<a href="{{ item.link.url }}" class="footer-logo" target="_blank">
+						{% else %}
+							<div class="footer-logo">
+						{% endif %}
 
-				{% set srcset = function('wp_get_attachment_image_srcset',  item.logo.id, 'large' ) %}		
-				<div class="image">
-					<img data-src="{{ item.logo.sizes.thumbnail }}" width="{{ item.logo.sizes.thumbnail_width }}" height="{{ item.logo.sizes.thumbnail_height }}" alt="{{ item.logo.alt }}" class="lazyload" {% if srcset %}data-srcset="{{ srcset }}"{% endif %} {% if sizes %}sizes="{{ sizes }}"{% endif %}>
+						{% set srcset = function('wp_get_attachment_image_srcset',  item.logo.id, 'large' ) %}		
+						<div class="image">
+							<img data-src="{{ item.logo.sizes.thumbnail }}" width="{{ item.logo.sizes.thumbnail_width }}" height="{{ item.logo.sizes.thumbnail_height }}" alt="{{ item.logo.alt }}" class="lazyload" {% if srcset %}data-srcset="{{ srcset }}"{% endif %} {% if sizes %}sizes="{{ sizes }}"{% endif %}>
+						</div>
+						
+						{% if item.link %}
+							</a>
+						{% else %}
+							</div>
+						{% endif %}
+						
+					{% endfor %}
 				</div>
-				
-				{% if item.link %}
-					</a>
-				{% else %}
-					</div>
-				{% endif %}
-				
-			{% endfor %}
-		</nav>
-		{% endif %}
-		
+			{% endif %}
+	</div>
+	<div class="container grid columns-4">
 		<div class="footer-copyright f-14">
 			<p>
 				{{ options.footer.copyright }}
 			</p>
 		</div>
-
-	</div>	
+	</div>
 	<svg class="icon icon-marque"><use xlink:href="#icon-marque"></use></svg>
 </footer>


### PR DESCRIPTION
Change to footer layout to accommodate more than one logo. Removal of an empty property within the css. Screenshots from Chrome below:

Desktop:
![image](https://user-images.githubusercontent.com/1905649/206175902-b893d900-2df3-40cb-bb6f-3cd80c02bb93.png)

Mobile:
![image](https://user-images.githubusercontent.com/1905649/206175989-5575b7db-0f9d-40ca-b78e-9b6aa83879de.png)
