### PR TITLE
Replace google maps api key with one we own

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ $addedlovely = (object) array(
 	'load_pinterest'		=>	false,
 	'ga_tracking_code'		=>	1234,
 	'google_conversion_id'	=>	false,
-	'google_maps_api_key'	=>	'AIzaSyB18ykHpKlyiSbefcpo0VxnN6MXKeWSRK0',
+	'google_maps_api_key'	=>	'AIzaSyA-9sCCe0-I6upuidqx5T1BvGZELfXhlfY',
 	'instgram_userId'		=>	1543748188,
 	'instagram_clientId'	=>	false,
 	'instagram_accessToken'	=>	false,
@@ -47,7 +47,7 @@ function addedlovely_child_styles() {
 	wp_enqueue_style( 'child-css', get_stylesheet_directory_uri() . '/style.css', '');
 	
 	if (is_page(10)) {
-		wp_enqueue_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?key=AIzaSyBsjUSPYF9c8AixI8l68_aUfnQMlly0OfU&callback=page_contact&v=weekly',false, '4.0.9', true );	
+		wp_enqueue_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?key=AIzaSyA-9sCCe0-I6upuidqx5T1BvGZELfXhlfY&callback=page_contact&v=weekly',false, '4.0.9', true );	
 		array_push($dependencies, 'google-maps');
 	}
 	


### PR DESCRIPTION
@ChrisScottThomas @lubomski API key swapped out as discussed.

After some more thought - I'm not sure we should treat this as secret after all, as it makes it's way in the the JS that is served to the browser.

<img width="944" alt="Screenshot 2023-02-01 at 11 10 54" src="https://user-images.githubusercontent.com/2734580/216027243-c88b6040-5777-4c4d-9e6a-0a03cc469ad5.png">

https://developers.google.com/maps/documentation/javascript/get-api-key